### PR TITLE
feat: Add feature1 list function

### DIFF
--- a/Work/Masters/a.java
+++ b/Work/Masters/a.java
@@ -1,0 +1,5 @@
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World! Hello, Jayden!");
+    }
+}

--- a/Work/Masters/b.swift
+++ b/Work/Masters/b.swift
@@ -1,0 +1,1 @@
+print("Hello, World! Hello, Jayden!")

--- a/Work/Masters/c.js
+++ b/Work/Masters/c.js
@@ -1,0 +1,1 @@
+console.log('Hello, World! Hello, Jayden!');

--- a/app.ts
+++ b/app.ts
@@ -1,0 +1,11 @@
+import { InputReceiver } from './input_receiver';
+
+class App {
+  private readonly inputReceiver: InputReceiver = new InputReceiver();
+  private readonly mitCommander: MitCommander = new MitCommander();
+  constructor() {
+    (async () => {
+      const command = await this.inputReceiver.getInput();
+    })();
+  }
+}

--- a/app.ts
+++ b/app.ts
@@ -1,11 +1,21 @@
 import { InputReceiver } from './input_receiver';
+import { MitCommander } from './mit_commander';
 
 class App {
   private readonly inputReceiver: InputReceiver = new InputReceiver();
-  private readonly mitCommander: MitCommander = new MitCommander();
+  private mitCommander!: MitCommander;
   constructor() {
     (async () => {
-      const command = await this.inputReceiver.getInput();
+      const commands = (await this.inputReceiver.getInput()).split(' ');
+      const mainCommand = commands[0];
+      const subCommand = commands[1];
+      const directory = commands[2];
+
+      if (mainCommand !== 'mit')
+        throw new Error('첫번째 command가 mit가 아닙니다.');
+      this.mitCommander = new MitCommander(subCommand, directory);
     })();
   }
 }
+
+const app = new App();

--- a/input_receiver.ts
+++ b/input_receiver.ts
@@ -1,0 +1,24 @@
+import readline from 'readline';
+
+export class InputReceiver {
+  private rl: readline.Interface;
+  constructor() {
+    this.rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  }
+
+  async getInput(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.rl.on('line', (line) => {
+        resolve(line);
+      });
+    });
+  }
+
+  close() {
+    this.rl.close();
+    process.exit();
+  }
+}

--- a/mit_commander.ts
+++ b/mit_commander.ts
@@ -1,0 +1,27 @@
+const fs = require('fs/promises');
+const os = require('os');
+
+export class MitCommander {
+  private readonly subCommand: string;
+  private readonly directory: string;
+  constructor(subCommand: string, directory: string) {
+    this.subCommand = subCommand;
+    this.directory = directory;
+
+    switch (subCommand) {
+      case 'list':
+        this.list();
+    }
+  }
+
+  private async list(): Promise<void> {
+    // test path: ~/dev-github/codesquad/cs16_common_mit/Work/Masters
+    const path = `${os.homedir()}${this.directory.replace('~', '')}`;
+    const fileNames = await fs.readdir(path);
+    for (const fileName of fileNames) {
+      console.log(
+        `${fileName} ${(await fs.stat(`${path}/${fileName}`)).size / 1000}KB`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## 🪴 새로 알게 된 내용

- `fs/promise` 모듈: 전반적으로 nodejs의 fs와 유사하지만, promise 객체로 반환한다.
  - async/await를 통해 비동기 처리를 해주니, 훨씬 코드 가독성이 좋아졌다.
- `os` 모듈
  - `os.homedir()` api: command로 전달하는 형태의 path에 home directory를 붙여서 fs의 readdir에 전달하기 위해 사용했다. ex) `/Users/username`을 반환한다.(mac os기준)`

<img width="632" alt="스크린샷 2023-02-27 20 48 16" src="https://user-images.githubusercontent.com/86241737/221556310-b77163c7-4cc1-4b20-aa83-7e3582bb72fc.png">