### PR TITLE
[feat] 3단계: zlib 명령어 구현

### DIFF
--- a/CS16-effie/CS16-effie/Data+hash.swift
+++ b/CS16-effie/CS16-effie/Data+hash.swift
@@ -13,4 +13,9 @@ extension Data {
     let hashDigest = SHA256.hash(data: self)
     return hashDigest.compactMap { String(format: "%02x", $0) }.joined()
   }
+  
+  var zlib: Data? {
+    guard let compressed = try? (self as NSData).compressed(using: .zlib) else { return nil }
+    return Data(compressed)
+  }
 }

--- a/CS16-effie/CS16-effie/Mit.swift
+++ b/CS16-effie/CS16-effie/Mit.swift
@@ -12,8 +12,7 @@ final class Mit {
     return FileManager.default
   }
   
-  private static func getEntitiesURL(from path: String) throws -> [URL] {
-    let directoryURL = URL(filePath: path)
+  private static func getContentsURL(from directoryURL: URL) throws -> [URL] {
     return try fileManager.contentsOfDirectory(
       at: directoryURL,
       includingPropertiesForKeys: nil,
@@ -21,66 +20,54 @@ final class Mit {
     )
   }
   
-  private static func list(_ path: String) -> [ListOutput] {
-    var outputs: [ListOutput] = []
-    do {
-      let entities = try getEntitiesURL(from: path)
-      outputs = entities.compactMap { entity in
-        let name = entity.lastPathComponent
-        guard let size = entity.fileByteSize else { return nil }
-        return ListOutput(fileName: name, info: size)
-      }
-    } catch {
-      print(error)
-    }
-    return outputs
+  private static func mapContents<Output: MitOutput>(
+    of directoryURL: URL,
+    transform: (URL) throws -> (Output)?
+  ) throws -> [Output] {
+    let entities = try getContentsURL(from: directoryURL)
+    return try entities.compactMap(transform)
   }
   
-  private static func hash(_ path: String) -> [HashOutput] {
-    var outputs: [HashOutput] = []
-    do {
-      let entities = try getEntitiesURL(from: path)
-      outputs = entities.compactMap { entity -> HashOutput? in
-        let name = entity.lastPathComponent
-        guard let data = entity.data else { return nil }
-        let hash = data.hash
-        return HashOutput(fileName: name, info: hash)
-      }
-    } catch {
-      print(error)
+  private static func list(_ directoryURL: URL) throws -> [ListOutput] {
+    let listTransform = { (entity: URL) -> ListOutput? in
+      let name = entity.lastPathComponent
+      guard let size = entity.fileByteSize else { return nil }
+      return ListOutput(fileName: name, info: size)
     }
-    return outputs
+    return try mapContents(of: directoryURL, transform: listTransform)
   }
   
-  private static func zlib(_ path: String) -> [ListOutput] {
-    let pathURL = URL(filePath: path)
-    var outputs: [ListOutput] = []
-    
-    do {
-      let entities = try getEntitiesURL(from: path)
-      outputs = try entities.compactMap { (entity: URL) -> ListOutput? in
-        let fileName = entity.lastPathComponent
-        
-        let newFileName = fileName + ".z"
-        let newFileURL = pathURL.appending(component: newFileName)
-        
-        guard let zlib = entity.data?.zlib else { throw MitError.CannotCompress }
-        try zlib.write(to: newFileURL)
-        
-        guard let zlibSize = newFileURL.fileByteSize else { return nil }
-        return ListOutput(fileName: newFileName, info: zlibSize)
-      }
-    } catch {
-      print(error)
+  private static func hash(_ directoryURL: URL) throws -> [HashOutput] {
+    let hashTransform = { (entity: URL) -> HashOutput? in
+      let name = entity.lastPathComponent
+      guard let data = entity.data else { return nil }
+      let hash = data.hash
+      return HashOutput(fileName: name, info: hash)
     }
-    return outputs
+    return try mapContents(of: directoryURL, transform: hashTransform)
   }
   
-  private static func process(_ command: MitCommand) -> [any MitOutput] {
+  private static func zlib(_ directoryURL: URL) throws -> [ListOutput] {
+    let zlibTransform = { (entity: URL) throws -> ListOutput?  in
+      let fileName = entity.lastPathComponent
+      
+      let newFileName = fileName + ".z"
+      let newFileURL = directoryURL.appending(component: newFileName)
+      
+      guard let zlib = entity.data?.zlib else { throw MitError.CannotCompress(fileName) }
+      try zlib.write(to: newFileURL)
+      
+      guard let zlibSize = newFileURL.fileByteSize else { return nil }
+      return ListOutput(fileName: newFileName, info: zlibSize)
+    }
+    return try mapContents(of: directoryURL, transform: zlibTransform)
+  }
+  
+  private static func process(_ command: MitCommand) throws -> [any MitOutput] {
     switch command {
-    case .list(let path): return list(path)
-    case .hash(let path): return hash(path)
-    case .zlib(let path): return zlib(path)
+    case .list(let path): return try list(path.fileSystemURL)
+    case .hash(let path): return try hash(path.fileSystemURL)
+    case .zlib(let path): return try zlib(path.fileSystemURL)
     }
   }
   
@@ -94,14 +81,13 @@ final class Mit {
         }
         
         let command = try MitCommand.getCommand(from: input)
-        let outputs = process(command)
+        let outputs = try process(command)
         MitIOManager.printOutput(outputs)
-        
       } catch {
         if let mitError = error as? MitError {
           print(mitError.actionMessage)
         } else {
-          print(error)
+          print(error.localizedDescription)
         }
       }
       

--- a/CS16-effie/CS16-effie/MitCommand.swift
+++ b/CS16-effie/CS16-effie/MitCommand.swift
@@ -7,18 +7,10 @@
 
 import Foundation
 
-enum MitCommand: CustomStringConvertible {
+enum MitCommand {
   case list(path: String)
   case hash(path: String)
   case zlib(path: String)
-  
-  var description: String {
-    switch self {
-    case .list(let p): return "list - \(p)"
-    case .hash(let p): return "hash - \(p)"
-    case .zlib(let p): return "zlib - \(p)"
-    }
-  }
   
   static func getCommand(from input: String) throws -> MitCommand {
     let elems = input.components(separatedBy: .whitespaces)

--- a/CS16-effie/CS16-effie/MitError.swift
+++ b/CS16-effie/CS16-effie/MitError.swift
@@ -15,14 +15,14 @@ enum MitError: Error {
   case NotMit(_ command: String)
   case InvalidCommand
   case CannotFetchDirectoryInfo
-  case CannotCompress
+  case CannotCompress(_ fileName: String)
   
   var actionMessage: String {
     switch self {
     case .NotMit(let command): return "command not found: \(command)"
     case .InvalidCommand: return "존재하지 않는 mit 명령어입니다. 다시 입력해주세요."
     case .CannotFetchDirectoryInfo: return "디렉토리를 탐색할 수 없습니다."
-    case .CannotCompress: return "압축할 수 없는 파일이 있습니다."
+    case .CannotCompress(let fileName): return "\(fileName)을 압축할 수 없습니다."
     }
   }
 }

--- a/CS16-effie/CS16-effie/MitError.swift
+++ b/CS16-effie/CS16-effie/MitError.swift
@@ -15,12 +15,14 @@ enum MitError: Error {
   case NotMit(_ command: String)
   case InvalidCommand
   case CannotFetchDirectoryInfo
+  case CannotCompress
   
   var actionMessage: String {
     switch self {
     case .NotMit(let command): return "command not found: \(command)"
     case .InvalidCommand: return "존재하지 않는 mit 명령어입니다. 다시 입력해주세요."
     case .CannotFetchDirectoryInfo: return "디렉토리를 탐색할 수 없습니다."
+    case .CannotCompress: return "압축할 수 없는 파일이 있습니다."
     }
   }
 }

--- a/CS16-effie/CS16-effie/MitOutput.swift
+++ b/CS16-effie/CS16-effie/MitOutput.swift
@@ -21,7 +21,7 @@ struct ListOutput: MitOutput {
   var info: Int
   
   var description: String {
-    "\(fileName) \(info)KB"
+    "\(fileName) \(info)B"
   }
 }
 

--- a/CS16-effie/CS16-effie/String+url.swift
+++ b/CS16-effie/CS16-effie/String+url.swift
@@ -1,0 +1,14 @@
+//
+//  String+url.swift
+//  CS16-effie
+//
+//  Created by Effie on 2023/02/28.
+//
+
+import Foundation
+
+extension String {
+  var fileSystemURL: URL {
+    return URL(filePath: self)
+  }
+}

--- a/CS16-effie/CS16-effie/URL+fileSize.swift
+++ b/CS16-effie/CS16-effie/URL+fileSize.swift
@@ -8,18 +8,13 @@
 import Foundation
 
 extension URL {
-  var fileSize: Int? {
-    get throws {
-      guard self.isFileURL else { return nil }
-      let infos = try self.resourceValues(forKeys: [.fileSizeKey])
-      guard let sizeInByte = infos.fileSize else { return nil }
-      return sizeInByte
-    }
+  var fileByteSize: Int? {
+    guard let infos = try? self.resourceValues(forKeys: [.fileSizeKey]) else { return nil }
+    guard let sizeInByte = infos.fileSize else { return nil }
+    return sizeInByte
   }
   
   var data: Data? {
-    get throws {
-      try Data(contentsOf: self)
-    }
+    try? Data(contentsOf: self)
   }
 }

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 - [x]  학습 계획 작성
 - [ ]  미션 이해하면서 학습 키워드 정리
 - [x]  쪼개고 우선순위 정하기
-- [ ]  구현
+- [x]  구현
     - [x]  step 0: 입출력 및 명령어 파싱
     - [x]  step 1: list
-    - [ ]  step 2: hash
-    - [ ]  step 3: zlib
+    - [x]  step 2: hash
+    - [x]  step 3: zlib
 - [ ]  학습 정리
 
 ---
@@ -26,7 +26,7 @@
 - [x]  [step 2] hash
     1. CryptoKit - hash 함수
     2. 파일에 대한 hash 구하기
-- [ ]  [step 3] zlib
+- [x]  [step 3] zlib
     1. NSData가 제공하는 기능으로 압축하기
 
 ---
@@ -143,3 +143,115 @@ SHA256 Digest: d058287d76c9595fd7e27cee63880d87b39b284034de68a4f7a9bc9840ff0cf6
 자료를 찾다보니 이렇게 포매팅하는 방법이 있었다. 위에서 사용했던 인터페이스와 결과는 동일해서 채택하기로 했다.
 
 ## 3단계: zlib
+
+### 데이터 압축 하기
+
+[compressed(using:) | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/nsdata/3174960-compressed)
+
+[NSData.CompressionAlgorithm.zlib | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/nsdata/compressionalgorithm/zlib)
+
+데이터 압축도 Foundation이 제공하고 있다. compressed(using:) + compression algorithm 조합으로 사용하면 되는데… 그런데… 주의할 것이 하나 있다.
+
+compressed 메소드는 NSData의 메소드이기 때문에 bridging 해서 사용해야 한다는 것이다.
+
+### 파일 쓰기
+
+[[Swift/iOS] FileManager로 파일 생성(쓰기), 읽기, 삭제하기](https://leeari95.tistory.com/32)
+
+- path 추가 -
+- 새 path에 data 쓰기
+
+### TS - 파일 URL 경로
+
+```swift
+private static func zlib(_ path: String) -> [ListOutput] {
+    var outputs: [ListOutput] = []
+    do {
+      let entities = try getEntitiesURL(from: path)
+      outputs = try entities.compactMap { (entity: URL) -> ListOutput? in
+        guard let zlib = entity.data?.zlib else { return nil }
+        let fileName = entity.lastPathComponent
+        
+//        let fixedFileName = fileName.components(separatedBy: ".").first!
+//        print(fixedFileName)
+        
+        let newFileName = fixedFileName + ".z"
+        guard let pathURL = URL(string: path) else { return nil }
+        let newFileURL = pathURL.appending(component: newFileName)
+        print(newFileURL.absoluteString)
+        try zlib.write(to: newFileURL)
+        guard let zlibSize = newFileURL.fileSize else { return nil }
+        return ListOutput(fileName: newFileName, info: zlibSize)
+      }
+    } catch {
+      print(error)
+    }
+    return outputs
+  }
+```
+
+이런 식으로 문자열 URL을 만들어서 파일을 write하려고 했는데 아무리 수정을 해도 에러가 났다.
+
+한 번은 b.swfit.z 처럼 이름을 붙이면 확장자를 식별할 수가 없어서 그런 건가? 이런 뚱단지 같은 추측을 하고 이거다 하면서 좋아했다. 근데 수정을 해도 소용이 없었음.
+
+> [에러 내용]
+> 
+> 
+> **2023-02-28 14:16:34.506689+0900 CS16-effie[20150:977706] CFURLCopyResourcePropertyForKey failed because it was passed a URL which has no scheme**
+> 
+> **Error Domain=NSCocoaErrorDomain Code=518 "The file couldn’t be saved because the specified URL type isn’t supported." UserInfo={NSURL=/Users/effie/work/b.z}**
+> 
+
+아하 URL에 scheme을 지정해주지 않아서 그런 거였군. write가 어디에 저장하라는 건지 알 수가 없으니까 에러가 났던 것이다.
+
+그렇다면 이쯤에서 URL Scheme이 뭔지 짚고 넘어가자.
+
+일단 scheme은 사전적으로 계획, 설계 등의 뜻을 가지고 있는데, 개발 용어인 scheme에 가장 근접한 뜻은 ‘체계’ 정도가 될 것 같다.
+
+[Uniform Resource Identifier](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax)
+
+위키피디아 에서는 다음과 같이 설명하고 있다.
+
+> A URI has a scheme that refers to a specification for assigning identifiers within that scheme.
+> 
+
+해당 스킴 내에서 식별자를 할당하기 위한 사양을 참조하는 스킴을 갖는다…
+
+이게 무슨 리눅스 이즈 낫 유닉스 같은 소리일까.
+
+URI는 결국 Identifier, 즉 식별자이다. 내가 구현하고 있는 기능처럼 파일을 저장하거나, 특정 공간에 있는 데이터를 참조하거나 요청하는 작업 에 URI가 사용된다. 특정 리소스에 대한 작업을 할 때, 서로 다른 자원를 식별하기 위해서 존재하는 것이 URI인 것이다. 
+
+`URI = scheme ":" ["//" authority] path ["?" query] ["#" fragment]`
+
+이 공식은 위키피디아에서 가져온 URI의 generic syntax이다 . 다섯 가지 component가 중요한 순서대로 이루어져 있고, 스킴은 그 중 가장 앞에 존재하게 된다. 즉 스킴은 URI 구성 요소 중에서 가장 중요한 요소인 것이다.
+
+> As such, the URI syntax is a federated and extensible naming system wherein each scheme's specification may further restrict the syntax and semantics of identifiers using that scheme.
+> 
+
+스킴의 사양은 그 스킴을 사용하는 identifier의 syntax와 semantic을 제한한다. 즉 작업의 처리 주체는 특정 스킴의 사양을 토대로, 스킴에 따라 URI를 다르게 해석해서 작업을 처리하는 것이다.
+
+따라서 스킴 없이 전달된 URI로는 정확히 어떻게 이 URI를 사용할 것인지 결정할 수 없다.
+
+[write(to:options:) | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/data/1779858-write)
+
+> **`url`**
+> 
+> 
+> The location to write the data into.
+> 
+
+write는 전달된 URI가 어떤 시스템의 것인지, 정확히 어떤 시스템에 해당 데이터를 저장해야 하는지 알 수 없기 때문에 이런 URL로는 쓰기 작업을 할 수 없다며 에러를 보내온 것이다.
+
+그렇다면 파일 시스템을 위한 URI는 어떻게 작성해야 할까?
+
+[file URI scheme](https://en.wikipedia.org/wiki/File_URI_scheme)
+
+진행 중이었던 구현에서는 문자열로 path를 구성 → 문자열을 받는 이니셜라이저로 URL을 생성했는데…
+
+이런 방식보다는 확실히 로컬 파일 시스템을 받는 방식이 안전할 것 같다는 생각이 들었다. 나중에 path component를 추가하더라도…
+
+[init(fileURLWithPath:) | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/url/3126800-init)
+
+찾아보니까 파일 스킴에 path를 붙여주는 URL 이니셜라이저가 있었다. 활용해보자
+
+스킴을 추가하니 정상적으로 동작한다. 야호 !


### PR DESCRIPTION
디렉터리에 포함된 파일들을 zlib로 압축하는 zlib 압축 명령어 기능을 추가했습니다.
- 압축 관련 에러 추가
- 파일 시스템 URL 생성에 사용되고 있는 이니셜라이저 교체 (일부 적용)
- skip hidden 옵션 추가
- file size 속성 이름 변경 (추후 KB로 업데이트 예정)
- 일부 속성 throws getter -> optional 로 변경

공통 코드를 리팩토링하고, 불필요한 디버깅용 코드를 제거했습니다.

구현 과정과 관련한 내용으로 README.md 를 작성했습니다.
