### PR TITLE
Implement Mit zlib method

### DIFF
--- a/CommandLine.js
+++ b/CommandLine.js
@@ -54,7 +54,13 @@ class CommandLine {
         }
         break;
       case "zlib":
-        // this.mit.zlib(dirname);
+        try {
+          (await this.mit.zlib(dirname)).forEach(({ name, size }) => {
+            console.log(`${name} ${size}`);
+          });
+        } catch (err) {
+          console.log(err);
+        }
         break;
       default:
         console.log(`Command not found: mit ${cmd}`);


### PR DESCRIPTION
- Implement the Mit zlib method.
  - Use the `node:fs` module to read file stream and write file stream.
  - Use the `node:zlib` module to compress the read file stream and output the compressed `.z` file.